### PR TITLE
Add a cartodb file

### DIFF
--- a/cartodb-torque.html
+++ b/cartodb-torque.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Map: The Oldest Surviving Los Angeles Restaurants</title>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+    <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+    <style>
+      html, body, #map {
+        height: 100%;
+        padding: 0;
+        margin: 0;
+      }
+    </style>
+
+    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  </head>
+  <body>
+    <div id="map"></div>
+
+    <!-- include cartodb.js library -->
+    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+
+    <script>
+      function main() {
+        cartodb.createVis('map', 'https://danhillreports.cartodb.com/api/v2/viz/3f3f381e-3cb7-11e5-99d5-0e0c41326911/viz.json', {
+        })
+        .done(function(vis, layers) {
+          window.layers = layers;
+        })
+        .error(function(err) {
+          console.log(err);
+        });
+      }
+
+      window.onload = main;
+    </script>
+  </body>
+</html>

--- a/cartodb.html
+++ b/cartodb.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Map: The Oldest Surviving Los Angeles Restaurants</title>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+    <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+    <style>
+      html, body, #map {
+        height: 100%;
+        padding: 0;
+        margin: 0;
+      }
+    </style>
+
+    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  </head>
+  <body>
+    <div id="map"></div>
+
+    <!-- include cartodb.js library -->
+    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+
+    <script>
+      function main() {
+        cartodb.createVis('map', 'https://danhillreports.cartodb.com/api/v2/viz/2c22e308-3cb1-11e5-b527-0e853d047bba/viz.json', {
+        })
+        .done(function(vis, layers) {
+          window.layers = layers;
+        })
+        .error(function(err) {
+          console.log(err);
+        });
+      }
+
+      window.onload = main;
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a cartodb.html map that embeds a basic scatter choropleth scatter map that can be seen here: [http://cdb.io/1Iuo9Cr](http://cdb.io/1Iuo9Cr)

![](https://cartocdn-ashbu.global.ssl.fastly.net/danhillreports/api/v1/map/static/center/1e7198360c0226d4742ce917aacbcfb0:1438916517038.84/8/34.03900467904445/-118.13598632812499/458/330.png)

Note: data current as of 8:20 pm 
